### PR TITLE
Rename fleets to application or release 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:docker": "mocha --config tests/.mocharc.docker.js",
     "test:node": "mocha --config tests/.mocharc.js",
     "test:fast": "mocha --config tests/.mocharc.fast.js",
-    "test": "npm run clean && npm run lint && npm run build && npm run test:node",
+    "test": "npm run lint && npm run build && npm run test:node",
     "dev": "ts-node src/index.ts",
     "start": "node dist/index.js",
     "build": "npm run clean && tsc",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "balena-registry-proxy",
   "version": "1.0.1",
-  "description": "Proxied names for balena registry fleet images",
+  "description": "Proxied names for balena registry release images",
   "private": true,
   "main": "src/app",
   "scripts": {

--- a/src/balena.ts
+++ b/src/balena.ts
@@ -43,7 +43,7 @@ export const lookupReleaseImage = memoizee(
 																$alias: 'bta',
 																$expr: {
 																	bta: {
-																		slug: release.fleet.slug,
+																		slug: release.application.slug,
 																	},
 																},
 															},
@@ -54,7 +54,7 @@ export const lookupReleaseImage = memoizee(
 																	$alias: 'sbroa',
 																	$expr: {
 																		sbroa: {
-																			slug: release.fleet.slug,
+																			slug: release.application.slug,
 																		},
 																	},
 																},

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -11,7 +11,7 @@ export interface ImageLocation {
 }
 
 export interface ReleaseRef {
-	fleet: {
+	application: {
 		slug: string;
 		org: string;
 		name: string;
@@ -44,7 +44,7 @@ export const parseReleaseRef: (slug: string) => ReleaseRef | undefined = (
 	const [org, name, version, service] = slug.split('/').filter(Boolean);
 	return name != null
 		? ({
-				fleet: {
+				application: {
 					org,
 					name,
 					slug: [org, name].filter(Boolean).join('/'),

--- a/tests/.mocharc.docker.js
+++ b/tests/.mocharc.docker.js
@@ -1,7 +1,7 @@
 module.exports = {
 	bail: false,
-	exit: true,
-	recursive: true,
+	exit: false,
+	recursive: false,
 	spec: ['dist/tests/docker/*.spec.js'],
 	timeout: '30000',
 };

--- a/tests/.mocharc.fast.js
+++ b/tests/.mocharc.fast.js
@@ -1,7 +1,7 @@
 module.exports = {
     bail: true,
-	exit: true,
-	recursive: true,
+	exit: false,
+	recursive: false,
     require: [
         'ts-node/register/transpile-only',
     ],

--- a/tests/.mocharc.js
+++ b/tests/.mocharc.js
@@ -1,7 +1,7 @@
 module.exports = {
 	bail: false,
-	exit: true,
-	recursive: true,
+	exit: false,
+	recursive: false,
 	spec: ['dist/tests/src/*.spec.js'],
 	timeout: '30000',
 };

--- a/tests/docker/docker.spec.ts
+++ b/tests/docker/docker.spec.ts
@@ -7,7 +7,7 @@ import { parseReleaseRef } from '../../src/parse';
 const docker = new Docker();
 
 const releaseRef = parseReleaseRef(config.test.repo);
-const baseImage = `localhost:${config.server.port}/${releaseRef?.fleet.slug}`;
+const baseImage = `localhost:${config.server.port}/${releaseRef?.application.slug}`;
 
 const releases = Array.from(
 	new Set([

--- a/tests/src/app.spec.ts
+++ b/tests/src/app.spec.ts
@@ -8,7 +8,7 @@ const manifestSchema = 'application/vnd.docker.distribution.manifest.v2+json';
 const apiVersion = 'registry/2.0';
 const userAgent = 'docker/20.10.7';
 const releaseRef = parseReleaseRef(config.test.repo);
-const fleet = releaseRef?.fleet.slug;
+const application = releaseRef?.application.slug;
 
 const releases = Array.from(
 	new Set([
@@ -33,7 +33,7 @@ const basicAuth = Buffer.from(
 
 releases.forEach((release) => {
 	services.forEach((service) => {
-		const repo = [fleet, release, release != null ? service : undefined]
+		const repo = [application, release, release != null ? service : undefined]
 			.filter(Boolean)
 			.join('/');
 


### PR DESCRIPTION
Technically fleets are a type of application, and we expect
this service to be used for pulling releases from blocks, not
fleets, so application is the generic term from the SDK/API.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>