### PR TITLE
Add a secondary dockerfile for use with balena push

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:v13.0.5
+FROM node:16.13.2-alpine3.14
 
 WORKDIR /usr/src/app
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:fast": "mocha --config tests/.mocharc.fast.js",
     "test": "npm run lint && npm run build && npm run test:node",
     "dev": "ts-node src/index.ts",
-    "start": "node dist/index.js",
+    "start": "node dist/src/index.js",
     "build": "npm run clean && tsc",
     "prepack": "npm run build",
     "prepare": "husky install"


### PR DESCRIPTION
Dockerfile.template does not use balena/open-balena-base
so it can be used for ARM architectures.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>