### PR TITLE
Skip packaging tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:fast": "mocha --config tests/.mocharc.fast.js",
     "test": "npm run lint && npm run build && npm run test:node",
     "dev": "ts-node src/index.ts",
-    "start": "node dist/src/index.js",
+    "start": "node dist/index.js",
     "build": "npm run clean && tsc",
     "prepack": "npm run build",
     "prepare": "husky install"

--- a/repo.yml
+++ b/repo.yml
@@ -1,6 +1,4 @@
 type: 'docker'
-release: github
-publishMetadata: true
 upstream:
   - repo: 'balena-sdk'
     url: 'https://github.com/balena-io/balena-sdk'

--- a/tests/.mocharc.js
+++ b/tests/.mocharc.js
@@ -2,6 +2,9 @@ module.exports = {
 	bail: false,
 	exit: false,
 	recursive: false,
-	spec: ['dist/tests/src/*.spec.js'],
+	require: [
+        'ts-node/register/transpile-only',
+    ],
+	spec: ['tests/src/*.spec.ts'],
 	timeout: '30000',
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,11 +19,8 @@
 	"include": [
 		"bin/**/*.ts",
 		"src/**/*.ts",
-		"tests/**/*.ts",
 		"typings/**/*.d.ts",
 		"*.ts"
 	],
-	"exclude": [
-		"node_modules"
-	]
+	"exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
When tests were not included in the Dockerfile
the src directory was being flattened leading
to incorrect paths.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>