### PR TITLE
Proxy all unauthenticated requests rather than rejecting

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,7 @@
-version: '2'
+version: "2"
 
 services:
+
   proxy:
     image: balena/open-balena-registry-proxy
     build:
@@ -8,20 +9,28 @@ services:
       dockerfile: Dockerfile
     environment:
       PROXY_PORT: 5000
-      REGISTRY2_HOST: registry2.balena-staging.com
+      REGISTRY2_HOST: registry2.balena-cloud.com
 
   docker:
     image: docker:dind
     privileged: true
     environment:
       DOCKER_TLS_CERTDIR: ""
-    command: --insecure-registry proxy:5000 --tls=false
+    command: --insecure-registry proxy:5000 --tls=false --debug
 
   sut:
     image: docker:latest
-    command: sh -c 'while ! docker info; do sleep 1; done; docker pull proxy:5000/chriscw/awesomebrowserblock'
+    command: >-
+      sh -c 'while ! docker info; do sleep 1; done;
+      docker build . &&
+      docker buildx create --name sut --config /buildkitd.toml --driver-opt network=host --use &&
+      docker buildx build --pull .'
     depends_on:
       - proxy
       - docker
     environment:
       DOCKER_HOST: tcp://docker:2375
+    volumes:
+      - ./tests/fixtures/src:/src:ro
+      - ./tests/fixtures/buildkitd.toml:/buildkitd.toml:ro
+    working_dir: /src

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,7 +46,7 @@ function rewriteRepository(
 
 	if (!req.headers['authorization']) {
 		// we need the authorization header with a JWT to go any further
-		return res.status(403).json(ERROR_DENIED);
+		return next();
 	}
 
 	const auth = authorization.parse(req.headers['authorization']);

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,10 +43,12 @@ export const REGISTRY2_HOST = optionalVar(
 	'registry2.balena-cloud.com',
 );
 
-export const REGISTRY_URL =
+export const REGISTRY_URL = optionalVar(
+	'REGISTRY_URL',
 	DNS_TLD != null
 		? `https://registry2.${DNS_TLD}`
-		: `https://${REGISTRY2_HOST}`;
+		: `https://${REGISTRY2_HOST}`,
+);
 
 export const PROXY_PORT = intVar('PROXY_PORT', 80);
 

--- a/tests/fixtures/buildkitd.toml
+++ b/tests/fixtures/buildkitd.toml
@@ -1,0 +1,6 @@
+debug = true
+insecure-entitlements = [ "network.host", "security.insecure"]
+
+[registry."proxy:5000"]
+  http = true
+  insecure = true

--- a/tests/fixtures/src/Dockerfile
+++ b/tests/fixtures/src/Dockerfile
@@ -1,0 +1,1 @@
+FROM proxy:5000/balena/open-balena-registry-proxy

--- a/tests/src/app.spec.ts
+++ b/tests/src/app.spec.ts
@@ -47,7 +47,7 @@ access.forEach((item) => {
 		it('should respond with OK', function (done) {
 			const jwt = generateToken('', '', [item]);
 			request(app(REGISTRY_URL))
-				.get(`/v2/${item.alias}/blobs/latest`)
+				.get(`/v2/${item.alias}/manifests/latest`)
 				.set('Authorization', `Bearer ${jwt}`)
 				.send()
 				.expect(200, done);


### PR DESCRIPTION
Buildkit does not send an initial /v2 request for authentication
but instead requests the entire image path without an auth header.

We need to forward this upstream so the registry can respond with
authentication instructions.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-io/open-balena-registry-proxy/issues/32