### PR TITLE
flowzone: Remove deprecated docker_platforms command

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -19,7 +19,7 @@ jobs:
       DOCKER_REGISTRY_PASS: ${{ secrets.DOCKER_REGISTRY_PASS }}
       BALENA_API_KEY: ${{ secrets.BALENA_API_KEY_PUSH }}
     with:
-      docker_platforms: linux/amd64
-      docker_images: docker.io/balena/open-balena-registry-proxy,ghcr.io/balena-io/open-balena-registry-proxy
-      balena_slugs: balena/open-balena-registry-proxy
-
+      docker_images: |
+        docker.io/balena/open-balena-registry-proxy
+      balena_slugs: |
+        balena/open-balena-registry-proxy


### PR DESCRIPTION
The default is amd64 now and advanced features require a bake file.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>